### PR TITLE
Either eask or cask needs to be used to open emacs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,3 +459,13 @@ and admiration.
 [emake]: https://github.com/vermiculus/emake.el
 [MELPA]: https://melpa.org
 [lsp-mode]: https://emacs-lsp.github.io/lsp-mode/
+
+# Using Emacs on its own
+
+Some of the functionality offer by elsa while using Emacs, like
+autocompletion and syntax check, might be accomplish by using both
+‘company-mode’ and ‘flycheck-mode’ which are available out of the box in
+Emacs.
+
+This project is set up to provide a lot more, but it's worth knowing
+that some functionality exist within Emacs on its own.

--- a/README.md
+++ b/README.md
@@ -276,8 +276,9 @@ scratch (like when running through flycheck or flymake).
 
 Elsa currently supports [lsp-mode][lsp-mode], but it is not yet
 built-in to lsp-mode itself because it (Elsa LSP) is not stable
-enough.  To use Elsa LSP, you must use `eask emacs` (or cask) to start
-emacs, run `(require 'elsa-lsp)` and then `(elsa-lsp-register)` or `M-x
+enough.  To use Elsa LSP, you must `cd` to the project directory, and
+use the command `eask emacs` (or `cask emacs`) to start emacs, run 
+`(require 'elsa-lsp)` and then `(elsa-lsp-register)` or `M-x
 elsa-lsp-register`to register the client with `lsp-mode`.  After that,
 using `M-x lsp` in an Elisp buffer will start a workspace.
 

--- a/README.md
+++ b/README.md
@@ -276,7 +276,8 @@ scratch (like when running through flycheck or flymake).
 
 Elsa currently supports [lsp-mode][lsp-mode], but it is not yet
 built-in to lsp-mode itself because it (Elsa LSP) is not stable
-enough.  To use Elsa LSP, run `(elsa-lsp-register)` or `M-x
+enough.  To use Elsa LSP, you must use `eask emacs` to start emacs,
+run `(require 'elsa-lsp)` and then `(elsa-lsp-register)` or `M-x
 elsa-lsp-register`to register the client with `lsp-mode`.  After that,
 using `M-x lsp` in an Elisp buffer will start a workspace.
 

--- a/README.md
+++ b/README.md
@@ -276,8 +276,8 @@ scratch (like when running through flycheck or flymake).
 
 Elsa currently supports [lsp-mode][lsp-mode], but it is not yet
 built-in to lsp-mode itself because it (Elsa LSP) is not stable
-enough.  To use Elsa LSP, you must use `eask emacs` to start emacs,
-run `(require 'elsa-lsp)` and then `(elsa-lsp-register)` or `M-x
+enough.  To use Elsa LSP, you must use `eask emacs` (or cask) to start
+emacs, run `(require 'elsa-lsp)` and then `(elsa-lsp-register)` or `M-x
 elsa-lsp-register`to register the client with `lsp-mode`.  After that,
 using `M-x lsp` in an Elisp buffer will start a workspace.
 


### PR DESCRIPTION
Following the current instructions in the readme of installing elsa using `(depends-on "elsa")` on either eask or cask, I had a little bit of problems understanding that I needed to open emacs using either `eask emacs` or `cask emacs` from the project directory. The reason this is required is due to the following two reasons:

1.- In order for emacs to access the packages installed by eask or cask on the project.
2.- But most importantly, if emacs is opened like I usually open it, when lsp-mode tries to start elsa, eask or cask would complain about not finding the Eask or Cask project file, due to the fact that it will try to start elsa-lsp on the the user's folder (~/). So it is crucial to `cd` to the project folder before running `eask emacs` or `cask emacs` from there.